### PR TITLE
Story timing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ pom.xml.asc
 *.swp
 *.swo
 /tmp
-.secrets.edn
+*.secrets.edn

--- a/src/clubhouse_metrics2/story_mapper.clj
+++ b/src/clubhouse_metrics2/story_mapper.clj
@@ -10,12 +10,16 @@
             [clubhouse-metrics2.caller :as caller]
             [clubhouse-metrics2.clubhouse :as clubhouse]))
 
-; 1. Get story function working in repl
-; 1.5 rename stuff to relevant actions
-; 2. Add duration in days to output (in addition to hours)
-
-
-(defn story [id]
+(defn story-body [id]
   "Given a clubhouse story id, return story data."
     (caller/get-url (clubhouse/story-url id)))
+
+(defn story-times [id]
+  "Given a story id, return its start and end time in hash map"
+  (hash-map
+    :start_time (c/to-date-time (get-in (story-body id) [:body :started_at])),
+    :end_time (c/to-date-time (get-in (story-body id) [:body :completed_at]))))
+
+(defn story-authors [id]
+  )
 

--- a/src/clubhouse_metrics2/story_timer.clj
+++ b/src/clubhouse_metrics2/story_timer.clj
@@ -1,17 +1,11 @@
 (ns clubhouse-metrics2.story-timer
   (:require [clj-time.core :as t]
-            [clj-time.coerce :as c]))
+            [clj-time.coerce :as c]
+            [clubhouse-metrics2.story-mapper :as smapper]
+            [clubhouse-metrics2.time-extractor :as textract]
+            [clubhouse-metrics2.tictoc :as tictoc]))
 
 
-(def timer
-    (with-open [r (io/reader "output.json")]
-      (edn/read (java.io.PushbackReader. r))))
-  (def starttime (get-in timer [:body :started_at]))
-  (def endtime (get-in timer [:body :completed_at]))
-  (def startdt (c/to-date-time starttime))
-  (def enddt (c/to-date-time endtime))
-  (def duration (t/in-hours (t/interval startdt enddt)))
-  (with-open [w (clojure.java.io/writer  "storydur.csv" :append true)]
-    (.write w (println-str duration (apply str ", " (storyaccess :story-id))))))
-
-(defn storytiming [])
+(defn duration [id]
+  (tictoc/days-between (textract/parse-times (smapper/story id)))
+  )

--- a/src/clubhouse_metrics2/story_timer.clj
+++ b/src/clubhouse_metrics2/story_timer.clj
@@ -1,11 +1,14 @@
 (ns clubhouse-metrics2.story-timer
   (:require [clj-time.core :as t]
             [clj-time.coerce :as c]
-            [clubhouse-metrics2.story-mapper :as smapper]
-            [clubhouse-metrics2.time-extractor :as textract]
-            [clubhouse-metrics2.tictoc :as tictoc]))
+            [clojure.java.io :as io]))
+
+(defn duration-days [times-hash]
+  "Takes in start and end time and delivers days between"
+  (t/in-days (t/interval (:start_time times-hash) (:end_time times-hash))))
+
+(defn duration-hours [times-hash]
+  "Takes in start and end time and delivers hours between"
+  (t/in-hours (t/interval (:start_time times-hash) (:end_time times-hash))))
 
 
-(defn duration [id]
-  (tictoc/days-between (textract/parse-times (smapper/story id)))
-  )

--- a/src/clubhouse_metrics2/tictoc.clj
+++ b/src/clubhouse_metrics2/tictoc.clj
@@ -1,0 +1,7 @@
+(ns clubhouse-metrics2.tictoc
+  (:require [clj-time.core :as t]
+            [clj-time.coerce :as c]
+            [clojure.java.io :as io]))
+
+(defn days-between [times-hash]
+  (t/in-days (t/interval (:start_time times-hash) (:end_time times-hash))))

--- a/src/clubhouse_metrics2/tictoc.clj
+++ b/src/clubhouse_metrics2/tictoc.clj
@@ -1,7 +1,0 @@
-(ns clubhouse-metrics2.tictoc
-  (:require [clj-time.core :as t]
-            [clj-time.coerce :as c]
-            [clojure.java.io :as io]))
-
-(defn days-between [times-hash]
-  (t/in-days (t/interval (:start_time times-hash) (:end_time times-hash))))

--- a/src/clubhouse_metrics2/time_extractor.clj
+++ b/src/clubhouse_metrics2/time_extractor.clj
@@ -1,0 +1,12 @@
+(ns clubhouse-metrics2.time-extractor
+  (:require [clojure.java.io :as io]
+            [clubhouse-metrics2.story-mapper :as smapper]
+            [clj-time.core :as t]
+            [clj-time.coerce :as c]))
+
+
+(defn parse-times [story-body]
+  "Given a story body, def its start and end time in hash map"
+  (hash-map
+    :start_time (c/to-date-time (get-in story-body [:body :started_at])),
+    :end_time (c/to-date-time (get-in story-body [:body :completed_at]))))


### PR DESCRIPTION
Goal: Provided a story ID, give the duration in days it took for the story to be completed.
- 1) Extract overloaded single function into steps e603a0280f6a972
- 2) Perform time calculation between provided start and end 235bdbdf727ef46
- 3) Extract times from story body provided using story mapper. 2d2d4c419020780
